### PR TITLE
Fix resolver declaration

### DIFF
--- a/src/jekyll/using_sonatype.md
+++ b/src/jekyll/using_sonatype.md
@@ -136,7 +136,9 @@ This file (kept *outside the VCS*) contains the Sonatype credentials settings:
 
 This file specifies the plugins for your project. If you intend to sign the artefacts, you'll need to include @jsuereth's `xsbt-gpg-plugin`:
 
-    resolvers += "sbt-plugin-releases" at "http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"
+    resolvers += Resolver.url("sbt-plugin-releases", /* no new line */
+      new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases")) /* no new line */
+      (Resolver.ivyStylePatterns)
     
     addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.5")
 


### PR DESCRIPTION
Unfortunately, the xsbt-gpg-plugin repository uses ivy style directory names, so that it won't work with the simple resolver declaration.
