### PR TITLE
Replaced the references to the github wiki with the searchable one

### DIFF
--- a/community-plugins.html
+++ b/community-plugins.html
@@ -40,7 +40,7 @@
         <p id="what">ensuring everything is possible.</p>
       </div>
       <div class="left page-description" id="vc">
-          <p>The <a href="http://github.com/sbt">SBT Organization</a> contains a <a href="http://github.com/sbt/sbt-community-plugins">SBT Community Plugins</a> project.   This project aims to unify all the SBT plugins in the community and ensure their compatibility and timely releases with new versions of SBT.  There is also a <a href="https://github.com/harrah/xsbt/wiki/sbt-0.10-plugins-list">list of plugins</a> that is up-to-date.</p>
+          <p>The <a href="http://github.com/sbt">SBT Organization</a> contains a <a href="http://github.com/sbt/sbt-community-plugins">SBT Community Plugins</a> project.   This project aims to unify all the SBT plugins in the community and ensure their compatibility and timely releases with new versions of SBT.  There is also a <a href="https://sbtwiki.backchat.io/sbt-0.10-plugins-list">list of plugins</a> that is up-to-date.</p>
 
       </div>
     </div>

--- a/howto/interactive.html
+++ b/howto/interactive.html
@@ -138,7 +138,7 @@ The default keybindings file is included in the sbt launcher and may be used as 
 
 <p>By default, sbt only displays <code>&gt;</code> to prompt for a command.
 This can be changed through the <code>shellPrompt</code> setting, which has type <code>State =&gt; String</code>.
-<a href="https://github.com/harrah/xsbt/wiki/Build-State">State</a> contains all state for sbt and thus provides access to all build information for use in the prompt string.</p>
+<a href="https://sbtwiki.backchat.io/Build-State">State</a> contains all state for sbt and thus provides access to all build information for use in the prompt string.</p>
 
 <p>Examples:</p>
 

--- a/howto/package.html
+++ b/howto/package.html
@@ -107,12 +107,12 @@
 <h4 id="name">Change the file name of a package</h4>
 
 
-<p>The <code>artifactName</code> setting controls the name of generated packages.  See the <a href="https://github.com/harrah/xsbt/wiki/Artifacts">Artifacts</a> page for details.</p>
+<p>The <code>artifactName</code> setting controls the name of generated packages.  See the <a href="https://sbtwiki.backchat.io/Artifacts">Artifacts</a> page for details.</p>
 
 <h4 id="contents">Modify the contents of the package</h4>
 
 
-<p>The contents of a package are defined by the <code>mappings</code> task, of type <code>Seq[(File,String)]</code>.  The <code>mappings</code> task is a sequence of mappings from a file to include in the package to the path in the package.  See the page on <a href="https://github.com/harrah/xsbt/wiki/Mapping-Files">mapping files</a> for convenience functions for generating these mappings.  For example, to add the file <code>in/example.txt</code> to the main binary jar with the path "out/example.txt",</p>
+<p>The contents of a package are defined by the <code>mappings</code> task, of type <code>Seq[(File,String)]</code>.  The <code>mappings</code> task is a sequence of mappings from a file to include in the package to the path in the package.  See the page on <a href="https://sbtwiki.backchat.io/Mapping-Files">mapping files</a> for convenience functions for generating these mappings.  For example, to add the file <code>in/example.txt</code> to the main binary jar with the path "out/example.txt",</p>
 
 <div class="highlight"><pre><code class="scala"><span class="n">mappings</span> <span class="n">in</span> <span class="o">(</span><span class="nc">Compile</span><span class="o">,</span> <span class="n">packageBin</span><span class="o">)</span> <span class="o">&lt;+=</span> <span class="n">baseDirectory</span> <span class="o">{</span> <span class="n">base</span> <span class="k">=&gt;</span>
    <span class="o">(</span><span class="n">base</span> <span class="o">/</span> <span class="s">&quot;in&quot;</span> <span class="o">/</span> <span class="s">&quot;example.txt&quot;</span><span class="o">)</span> <span class="o">-&gt;</span> <span class="s">&quot;out/example.txt&quot;</span>

--- a/howto/scala.html
+++ b/howto/scala.html
@@ -118,7 +118,7 @@
 <h4 id="cross">Build a project against multiple Scala versions</h4>
 
 
-<p>See <a href="https://github.com/harrah/xsbt/wiki/Cross-Build">cross building</a>.</p>
+<p>See <a href="https://sbtwiki.backchat.io/Cross-Build">cross building</a>.</p>
 
 <h4 id="console-quick">Enter the Scala REPL with a project's dependencies on the classpath, but not the compiled project classes</h4>
 
@@ -136,7 +136,7 @@
 <pre><code>&gt; console-project
 </code></pre>
 
-<p>For details, see the <a href="https://github.com/harrah/xsbt/wiki/Console-Project">console-project</a> page.</p>
+<p>For details, see the <a href="https://sbtwiki.backchat.io/Console-Project">console-project</a> page.</p>
 
 <h4 id="initial">Define the initial commands evaluated when entering the Scala REPL</h4>
 

--- a/howto/triggered.html
+++ b/howto/triggered.html
@@ -53,7 +53,7 @@
        </ul>
      </div></div>
     <div id="pagecontent" class="cf">
-      <p><a href="https://github.com/harrah/xsbt/wiki/Full-Configuration">Full Configuration</a></p>
+      <p><a href="https://sbtwiki.backchat.io/Full-Configuration">Full Configuration</a></p>
 
 <h4 id="basic">Run a command when sources change</h4>
 

--- a/learn.html
+++ b/learn.html
@@ -40,7 +40,7 @@
         <p id="what">From Basics to Wizardry</p>
       </div>
       <div class="left page-description" id="vc">
-          <p>We highly recommend trying the <a href="https://github.com/harrah/xsbt/wiki/Getting-Started-Welcome">Getting Started Guide</a>
+          <p>We highly recommend trying the <a href="https://sbtwiki.backchat.io/Getting-Started-Welcome">Getting Started Guide</a>
 before diving into sbt.  There are also a lot of great introductory <a href="talks.html">talks</a> available for your viewing pleasure.</p>
 
       </div>
@@ -52,7 +52,7 @@ before diving into sbt.  There are also a lot of great introductory <a href="tal
             
             
               
-                <li><a href="https://github.com/harrah/xsbt/wiki/Getting-Started-Welcome">Getting Started Guide</a></li>
+                <li><a href="https://sbtwiki.backchat.io/Getting-Started-Welcome">Getting Started Guide</a></li>
               
             
           
@@ -98,7 +98,7 @@ before diving into sbt.  There are also a lot of great introductory <a href="tal
             
             
               
-                <li><a href="https://github.com/harrah/xsbt/wiki">Wiki</a></li>
+                <li><a href="https://sbtwiki.backchat.io">Wiki</a></li>
               
             
           
@@ -108,7 +108,7 @@ before diving into sbt.  There are also a lot of great introductory <a href="tal
             
             
               
-                <li><a href="https://github.com/harrah/xsbt/wiki/FAQ">FAQ</a></li>
+                <li><a href="https://sbtwiki.backchat.io/FAQ">FAQ</a></li>
               
             
           


### PR DESCRIPTION
Hi,

I put up a searchable sbt wiki at https://sbtwiki.backchat.io  and updated the website to link to the searchable wiki.
