### PR TITLE
Add SBT version to example path for credentials file

### DIFF
--- a/src/jekyll/using_sonatype.md
+++ b/src/jekyll/using_sonatype.md
@@ -79,7 +79,7 @@ This might be advantageous if those keys are used also by other plugins (e.g. `l
 
 ## Fourth - Adding credentials ##
 
-The credentials for your Sonatype OSSRH account need to be added somewhere.  Common convention is a `~/.sbt/sonatype.sbt` file with the following:
+The credentials for your Sonatype OSSRH account need to be added somewhere.  Common convention is a `~/.sbt/<sbt version>/sonatype.sbt` file with the following:
 
     credentials += Credentials("Sonatype Nexus Repository Manager", 
                                "oss.sonatype.org", 


### PR DESCRIPTION
As of sbt 0.13, the credentials won't be found if they aren't within a version directory.
