### PR TITLE
Plugins-Best-Practices.html typos

### DIFF
--- a/0.13/docs/Plugins-Best-Practices.html
+++ b/0.13/docs/Plugins-Best-Practices.html
@@ -209,7 +209,7 @@ object Obfuscate {
 }
 </code></pre><p>The <code>baseObfuscateSettings</code> value provides base configuration for the
 plugin’s tasks. This can be re-used in other configurations if projects
-require it. The <code>obfuscateSettings</code> value provides the default <code>Compile</code>
+require it. The <code>projectSettings</code> value provides the default <code>Compile</code>
 scoped settings for projects to use directly. This gives the greatest
 flexibility in using features provided by a plugin. Here’s how the raw
 settings may be reused:

--- a/0.13/docs/offline/Plugins-Best-Practices.html
+++ b/0.13/docs/offline/Plugins-Best-Practices.html
@@ -209,7 +209,7 @@ object Obfuscate {
 }
 </code></pre><p>The <code>baseObfuscateSettings</code> value provides base configuration for the
 plugin’s tasks. This can be re-used in other configurations if projects
-require it. The <code>obfuscateSettings</code> value provides the default <code>Compile</code>
+require it. The <code>projectSettings</code> value provides the default <code>Compile</code>
 scoped settings for projects to use directly. This gives the greatest
 flexibility in using features provided by a plugin. Here’s how the raw
 settings may be reused:

--- a/1.0/docs/Plugins-Best-Practices.html
+++ b/1.0/docs/Plugins-Best-Practices.html
@@ -209,7 +209,7 @@ object Obfuscate {
 }
 </code></pre><p>The <code>baseObfuscateSettings</code> value provides base configuration for the
 plugin’s tasks. This can be re-used in other configurations if projects
-require it. The <code>obfuscateSettings</code> value provides the default <code>Compile</code>
+require it. The <code>projectSettings</code> value provides the default <code>Compile</code>
 scoped settings for projects to use directly. This gives the greatest
 flexibility in using features provided by a plugin. Here’s how the raw
 settings may be reused:

--- a/1.0/docs/offline/Plugins-Best-Practices.html
+++ b/1.0/docs/offline/Plugins-Best-Practices.html
@@ -209,7 +209,7 @@ object Obfuscate {
 }
 </code></pre><p>The <code>baseObfuscateSettings</code> value provides base configuration for the
 plugin’s tasks. This can be re-used in other configurations if projects
-require it. The <code>obfuscateSettings</code> value provides the default <code>Compile</code>
+require it. The <code>projectSettings</code> value provides the default <code>Compile</code>
 scoped settings for projects to use directly. This gives the greatest
 flexibility in using features provided by a plugin. Here’s how the raw
 settings may be reused:


### PR DESCRIPTION
`obfuscateSettings` no longer exists and should be `projectSettings`.